### PR TITLE
Export execute function from GraphQL module

### DIFF
--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,2 +1,3 @@
 export { getQueryName } from './getQueryName'
 export { LocalStorageCache, SessionStorageCache } from './cache'
+export { execute } from './execute'


### PR DESCRIPTION
Add the `execute` function export to the GraphQL module index for easier access.