### PR TITLE
Adjust publish trigger for GraphQL package

### DIFF
--- a/.github/workflows/packages-graphql-publish.yml
+++ b/.github/workflows/packages-graphql-publish.yml
@@ -2,9 +2,7 @@ name: Publish package (@com.46ki75/graphql)
 
 on:
   workflow_dispatch:
-  push: 
-    branches: 
-      - main
+  push:
     tags:
       - '@com.46ki75/graphql@*'
 


### PR DESCRIPTION
Modify the workflow to ensure the publish trigger only responds to tags for the GraphQL package.